### PR TITLE
correction trigger-up and down validation

### DIFF
--- a/controller/plugins/scheduler/default/plugin.py
+++ b/controller/plugins/scheduler/default/plugin.py
@@ -58,20 +58,25 @@ class DefaultScheduler(SchedulerBase):
                     "\"{}\" has unexpected variable type: {}. Was expecting {}"
                     .format(key, type(data[key]), data_model[key]))
 
-        if not (data['trigger_up'] isinstance(int)
-                or data['trigger_up'] isinstance(float)):
+        if 'trigger_up'not in data:
+            raise ex.BadRequestException(
+                    "Variable \"{}\" is missing".format(key))
+
+        if not (isinstance(data['trigger_up'], int) or
+                isinstance(data['trigger_up'], float)):
             raise ex.BadRequestException(
                 "\"trigger_up\" has unexpected variable type: {}. Was"
                 " expecting float or int".format(type(data['trigger_up'])))
 
-        if not (data['trigger_down'] isinstance(int) 
-                or data['trigger_down'] isinstance(float)):
+        if 'trigger_down' not in data:
+            raise ex.BadRequestException(
+                "Variable \"{}\" is missing".format(key))
+
+        if not (isinstance(data['trigger_down'], int) or
+                isinstance(data['trigger_down'], float)):
             raise ex.BadRequestException(
                 "\"trigger_down\" has unexpected variable type: {}. Was"
-                " expecting float or int".format(type(data['trigger_down']))
-                
-
-
+                " expecting float or int".format(type(data['trigger_down'])))
 
         if (data["min_rep"] < 1):
             raise ex.BadRequestException(

--- a/controller/plugins/scheduler/default/plugin.py
+++ b/controller/plugins/scheduler/default/plugin.py
@@ -46,9 +46,7 @@ class DefaultScheduler(SchedulerBase):
         data_model = {
             "actuation_size": int,
             "max_rep": int,
-            "min_rep": int,
-            "trigger_down": int,
-            "trigger_up": int,
+            "min_rep": int
         }
 
         for key in data_model:

--- a/controller/plugins/scheduler/default/plugin.py
+++ b/controller/plugins/scheduler/default/plugin.py
@@ -60,6 +60,21 @@ class DefaultScheduler(SchedulerBase):
                     "\"{}\" has unexpected variable type: {}. Was expecting {}"
                     .format(key, type(data[key]), data_model[key]))
 
+        if not (data['trigger_up'] isinstance(int)
+                or data['trigger_up'] isinstance(float)):
+            raise ex.BadRequestException(
+                "\"trigger_up\" has unexpected variable type: {}. Was"
+                " expecting float or int".format(type(data['trigger_up'])))
+
+        if not (data['trigger_down'] isinstance(int) 
+                or data['trigger_down'] isinstance(float)):
+            raise ex.BadRequestException(
+                "\"trigger_down\" has unexpected variable type: {}. Was"
+                " expecting float or int".format(type(data['trigger_down']))
+                
+
+
+
         if (data["min_rep"] < 1):
             raise ex.BadRequestException(
                 "Variable \"min_rep\" must be greater than 0")


### PR DESCRIPTION
Correcting the trigger-up and trigger-down validation, before this, only int values were accepted. Now float values are accepted as well.